### PR TITLE
Use AsCommand to fix empty name error

### DIFF
--- a/src/Commands/InspectCommand.php
+++ b/src/Commands/InspectCommand.php
@@ -6,6 +6,7 @@ namespace NunoMaduro\Patrol\Commands;
 
 use NunoMaduro\Patrol\Handlers\DependenciesList;
 use NunoMaduro\Patrol\Handlers\Score;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,14 +18,13 @@ use function NunoMaduro\Patrol\Support\collect;
 /**
  * @internal
  */
+#[AsCommand(
+    name: 'inspect',
+    hidden: false
+)]
 final class InspectCommand extends Command
 {
     use Concerns\InteractsWithIO;
-
-    /**
-     * The command name.
-     */
-    protected static $defaultName = 'inspect';
 
     /**
      * @var array<string, string>>

--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -58,7 +58,7 @@ class Collection
      *
      * @return self<TItem>
      */
-    public function filter(callable $callable = null): self
+    public function filter(?callable $callable = null): self
     {
         return new self(array_filter($this->items, $callable));
     }

--- a/src/Support/Functions.php
+++ b/src/Support/Functions.php
@@ -12,7 +12,7 @@ namespace NunoMaduro\Patrol\Support;
  * @param  TValue  $value
  * @return TValue
  */
-function tap($value, callable $callback = null)
+function tap($value, ?callable $callback = null)
 {
     if ($callback) {
         $callback($value);


### PR DESCRIPTION
Using AsCommand attribute for defining command name as recommended in [Symfony docs ](https://symfony.com/doc/current/console.html#registering-the-command) to avoid empty name error.
Fixes[#14]